### PR TITLE
Remove unused outputs

### DIFF
--- a/wdl/bowtie2_align/bowtie2_align.wdl
+++ b/wdl/bowtie2_align/bowtie2_align.wdl
@@ -41,7 +41,7 @@ task bowtie2_align {
         tar -zxvf ~{genome_dir_tar} -C ./genome/~{genome_dir} --strip-components 1
 
         echo "--- $(date "+[%b %d %H:%M:%S]") Indexing genome ---"
-        bowtie2 -p ~{ncpu} -1 ~{fastqr1} -2 ~{fastqr2} -x genome/~{genome_dir}/~{index_prefix} --local -S ~{SID}.sam 2> ~{SID}.log
+        bowtie2 -p ~{ncpu} -1 ~{fastqr1} -2 ~{fastqr2} -x genome/~{genome_dir}/~{index_prefix} --local -S /dev/null 2> ~{SID}.log
 
         echo "--- $(date "+[%b %d %H:%M:%S]") Transforming text ---"
         type=$(echo ~{genome_dir}|sed 's/rn_//1')
@@ -53,7 +53,6 @@ task bowtie2_align {
     >>>
 
     output {
-        File bowtie2_output = "${SID}.sam"
         File bowtie2_log = "${SID}.log"
         File bowtie2_report="${SID}_${genome_dir}_report.txt"
     }

--- a/wdl/mark_duplicates/mark_duplicates.wdl
+++ b/wdl/mark_duplicates/mark_duplicates.wdl
@@ -31,7 +31,6 @@ task markDuplicates {
     >>>
 
     output {
-        File umi_tagged_bam = 'dedup/${SID}_attached_R1_val_1.fq_trimmed_bismark_bt2_pe.bam'
         File deduped_bam = 'dedup/${SID}_attached_R1_val_1.fq_trimmed_bismark_bt2_pe.deduplicated.bam'
         File dedupLog= 'dedup/${SID}_attached_R1_val_1.fq_trimmed_bismark_bt2_pe.deduplication_report.txt'
     }

--- a/wdl/quantify_methylation/quantify_methylation.wdl
+++ b/wdl/quantify_methylation/quantify_methylation.wdl
@@ -97,9 +97,6 @@ workflow quantify_methylation {
             SID=SID
     }
     output {
-        File CpG_context=quantifyMethylation.CpG_context
-        File CHG_context=quantifyMethylation.CHG_context
-        File CHH_context=quantifyMethylation.CHH_context
         File M_Bias=quantifyMethylation.M_Bias
         File bedgraph=quantifyMethylation.bedgraph
         File bismark_cov=quantifyMethylation.bismark_cov

--- a/wdl/quantify_methylation/quantify_methylation.wdl
+++ b/wdl/quantify_methylation/quantify_methylation.wdl
@@ -45,7 +45,8 @@ task quantifyMethylation {
         bismark_methylation_extractor ~{SID}_attached_R1_val_1.fq_trimmed_bismark_bt2_pe.deduplicated.bam \
             --multicore ~{ncpu} \
             --comprehensive \
-            --bedgraph
+            --bedgraph \
+            --gzip
         echo "--- Finished: bismark_methylation_extractor ---"
 
         echo "------ Running : bismark2summary-------"
@@ -58,9 +59,6 @@ task quantifyMethylation {
     >>>
 
     output {
-        File CpG_context="CpG_context_${SID}_attached_R1_val_1.fq_trimmed_bismark_bt2_pe.deduplicated.txt"
-        File CHG_context="CHG_context_${SID}_attached_R1_val_1.fq_trimmed_bismark_bt2_pe.deduplicated.txt"
-        File CHH_context="CHH_context_${SID}_attached_R1_val_1.fq_trimmed_bismark_bt2_pe.deduplicated.txt"
         File M_Bias="${SID}_attached_R1_val_1.fq_trimmed_bismark_bt2_pe.deduplicated.M-bias.txt"
         File bedgraph="${SID}_attached_R1_val_1.fq_trimmed_bismark_bt2_pe.deduplicated.bedGraph.gz"
         File bismark_cov="${SID}_attached_R1_val_1.fq_trimmed_bismark_bt2_pe.deduplicated.bismark.cov.gz"


### PR DESCRIPTION
Potential output files to remove:

- **bowtie2_phix** [[x](https://github.com/MoTrPAC/motrpac-rrbs-pipeline/blob/master/wdl/bowtie2_align/bowtie2_align.wdl)]
  - `bowtie2_output = "${SID}.sam"`
- **mark_dup_sample** / **mark_dup_spike_in** [[x](https://github.com/MoTrPAC/motrpac-rrbs-pipeline/blob/master/wdl/mark_duplicates/mark_duplicates.wdl)]
  - `umi_tagged_bam = 'dedup/${SID}_attached_R1_val_1.fq_trimmed_bismark_bt2_pe.bam'`
- **quant_methyl_sample** / **quant_methyl_spike_in** [[x](https://github.com/MoTrPAC/motrpac-rrbs-pipeline/blob/master/wdl/quantify_methylation/quantify_methylation.wdl)]
  - `CpG_context="CpG_context_${SID}_attached_R1_val_1.fq_trimmed_bismark_bt2_pe.deduplicated.txt"`
  - `CHG_context="CHG_context_${SID}_attached_R1_val_1.fq_trimmed_bismark_bt2_pe.deduplicated.txt"`
  - `CHH_context="CHH_context_${SID}_attached_R1_val_1.fq_trimmed_bismark_bt2_pe.deduplicated.txt"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Alignment processing no longer produces a SAM file; log and report outputs remain available.
  * Duplicate-marking results now provide the deduplicated BAM file and log, without the intermediate UMI-tagged BAM file.
  * Methylation extraction now generates compressed bedgraph output. Separate CpG, CHG, and CHH context files are no longer provided as task outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->